### PR TITLE
BaseUrl Internal Representation Remake

### DIFF
--- a/Source/Core/RequestEnhancer/Enhancers/BaseUrl.swift
+++ b/Source/Core/RequestEnhancer/Enhancers/BaseUrl.swift
@@ -12,22 +12,21 @@ public struct BaseUrl: RequestModifier {
 
     public static let Ignore = BaseUrl(url: nil, priority: .fetcher)
 
-    internal let baseUrl: String?
+    internal let baseUrl: URL?
     internal let priority: RequestEnhancerPriority
 
     @available(*, deprecated, message: "Use `init(string:)`.")
     public init(baseUrl: String?, priority: RequestEnhancerPriority = .normal) {
-        self.baseUrl = baseUrl
-        self.priority = priority
+        self.init(string: baseUrl, priority: priority)
     }
 
     public init(string: String?, priority: RequestEnhancerPriority = .normal) {
-        self.baseUrl = string
+        self.baseUrl = URL(string: string ?? "")
         self.priority = priority
     }
 
     public init(url: URL?, priority: RequestEnhancerPriority = .normal) {
-        self.baseUrl = url?.absoluteString
+        self.baseUrl = url
         self.priority = priority
     }
 }

--- a/Source/Core/RequestEnhancer/Enhancers/Internal/BaseUrlRequestEnhancer.swift
+++ b/Source/Core/RequestEnhancer/Enhancers/Internal/BaseUrlRequestEnhancer.swift
@@ -14,19 +14,7 @@ internal struct BaseUrlRequestEnhancer: RequestEnhancer {
     
     internal func enhance(request: inout Request) {
         let modifier = request.modifiers.flatMap { $0 as? BaseUrl }.max { $0.priority.value < $1.priority.value }
-        if let url = request.url, var baseUrl = modifier?.baseUrl {
-
-            URLComponents.
-            var component = url.absoluteString
-            if component[component.startIndex] == "/" {
-                component = component.substring(from: component.index(after: component.startIndex))
-            }
-            
-            if baseUrl[baseUrl.index(before: baseUrl.endIndex)] == "/" {
-                baseUrl = baseUrl.substring(to: baseUrl.index(before: baseUrl.endIndex))
-            }
-            
-            request.url = URL(string: baseUrl + "/" + component)
-        }
+        guard let url = request.url, let baseUrl = modifier?.baseUrl else { return }
+        request.url = baseUrl.appendingPathComponent(url.absoluteString)
     }
 }

--- a/Source/Core/RequestEnhancer/Enhancers/Internal/BaseUrlRequestEnhancer.swift
+++ b/Source/Core/RequestEnhancer/Enhancers/Internal/BaseUrlRequestEnhancer.swift
@@ -13,9 +13,10 @@ internal struct BaseUrlRequestEnhancer: RequestEnhancer {
     internal static let priority: RequestEnhancerPriority = .fetcher
     
     internal func enhance(request: inout Request) {
-        let modifier = request.modifiers.flatMap { $0 as? BaseUrl }.sorted { $0.priority.value > $1.priority.value }.first
+        let modifier = request.modifiers.flatMap { $0 as? BaseUrl }.max { $0.priority.value < $1.priority.value }
         if let url = request.url, var baseUrl = modifier?.baseUrl {
 
+            URLComponents.
             var component = url.absoluteString
             if component[component.startIndex] == "/" {
                 component = component.substring(from: component.index(after: component.startIndex))

--- a/Tests/Core/RequestEnhancer/Enhancers/BaseUrlTest.swift
+++ b/Tests/Core/RequestEnhancer/Enhancers/BaseUrlTest.swift
@@ -26,7 +26,7 @@ class BaseUrlTest: QuickSpec {
                 
                 expect(url).toEventually(equal("abc/xyz"))
             }
-            it("solve conflicts by priority") {
+            it("solves conflicts by priority") {
                 let endpoint: GET<Void, Void> = GET("xyz", modifiers: BaseUrl(string: "abc"),
                                                     BaseUrl(string: "qwe", priority: .high), BaseUrl(string: "asd", priority: .low))
                 var url: String?
@@ -47,7 +47,7 @@ class BaseUrlTest: QuickSpec {
                 
                 expect(url).toEventually(equal("xyz"))
             }
-            it("constructs successfully using URL instead of String") {
+            it("constructs successfully using URL") {
                 let endpoint: GET<Void, Void> = GET("xyz", modifiers: BaseUrl(url: URL(string: "abc")))
                 var url: String?
 


### PR DESCRIPTION
This PR makes `BaseUrl` use URL inside which consequently makes the enhancer much simpler while still correct.